### PR TITLE
Merging to track utemplate

### DIFF
--- a/README
+++ b/README
@@ -28,3 +28,11 @@ micropython ../utemplate_util.py run squares.tpl
 or
 
 python3 ../utemplate_util.py run squares.tpl
+
+Templates can take parameters (that's how dynamic content is generated).
+Template parameters are passed as arguments to a generator function
+produced from a template. They also can be passed on the utemplate_util.py
+command line (arguments will be treated as strings in this case, but
+can be any types if called from your code):
+
+micropython ../utemplate_util.py run test1.tpl foo bar

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-utemplate is lightweight and memory-efficient template engine for
+utemplate is a lightweight and memory-efficient template engine for
 Python, primarily intended for usage with MicroPython
 (https://github.com/micropython/micropython).
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ command line (arguments will be treated as strings in this case, but
 can be of any types if called from your code):
 
     micropython ../utemplate_util.py run test1.tpl foo bar
+
+If you want to see a complete example web application which uses utemplate,
+refer to https://github.com/pfalcon/notes-pico .

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
+utemplate
+=========
+
 utemplate is a lightweight and memory-efficient template engine for
-Python, primarily intended for usage with MicroPython
+Python, primarily intended for use with MicroPython
 (https://github.com/micropython/micropython).
 
 utemplate syntax is roughly based on Django/Jinja2 syntax (e.g.
-"{% if %}"), but only the most needed features are offered (for
+`{% if %}`), but only the most needed features are offered (for
 example, "filters" are syntactic sugar for function calls, and
-so far not planned for implementation).
+so far are not planned to be implemented).
 
-utemplates compiles templates to Python source code, specifically to
+utemplate compiles templates to Python source code, specifically to
 a generator function which, being iterated over, produces consecutive
 parts (substrings) of a rendered template. This allows for minimal
 memory usage during template substitution (with MicroPython, it starts
 from mere hundreds of bytes). Generated Python code can be imported as
-a module directly, or simple loader class is provided for convenience.
-There is also loader class which will compile templates on the fly,
+a module directly, or a simple loader class is provided for convenience.
+There is also a loader class which will compile templates on the fly,
 if not already compiled (currently not automatically recompiled if
 changed, this is on TODO).
 
@@ -23,16 +26,16 @@ To test/manage templates, "utemplate_util.py" tool is provided. For
 example, to quickly try a template (assuming you are already in
 "examples/" dir):
 
-micropython ../utemplate_util.py run squares.tpl
+    micropython ../utemplate_util.py run squares.tpl
 
 or
 
-python3 ../utemplate_util.py run squares.tpl
+    python3 ../utemplate_util.py run squares.tpl
 
 Templates can take parameters (that's how dynamic content is generated).
 Template parameters are passed as arguments to a generator function
 produced from a template. They also can be passed on the utemplate_util.py
 command line (arguments will be treated as strings in this case, but
-can be any types if called from your code):
+can be of any types if called from your code):
 
-micropython ../utemplate_util.py run test1.tpl foo bar
+    micropython ../utemplate_util.py run test1.tpl foo bar

--- a/examples/test1.tpl
+++ b/examples/test1.tpl
@@ -1,5 +1,7 @@
 {% args var, another %}
 hello
+first arg: {{var}}
+second arg: {{another}}
 {% for i in range(5) %}
 {% if i % 2 %}
 world

--- a/utemplate_util.py
+++ b/utemplate_util.py
@@ -1,6 +1,12 @@
 import sys
-import uos as os
-import uio as io
+try:
+    import uos as os
+except ImportError:
+    import os
+try:
+    import uio as io
+except ImportError:
+    import io
 import utemplate.source
 import utemplate.compiled
 

--- a/utemplate_util.py
+++ b/utemplate_util.py
@@ -1,6 +1,6 @@
 import sys
-import os
-import _io as io
+import uos as os
+import uio as io
 import utemplate.source
 import utemplate.compiled
 

--- a/utemplate_util.py
+++ b/utemplate_util.py
@@ -5,6 +5,10 @@ import utemplate.source
 import utemplate.compiled
 
 
+if len(sys.argv) < 3:
+    print("Usage: %s <cmd> <template> [<template arg>...]" % sys.argv[0])
+    sys.exit(1)
+
 cmd = sys.argv[1]
 package = None
 
@@ -39,4 +43,4 @@ elif cmd == "run":
         sys.stdout.write(x)
 
 else:
-    print("Unknown command: ", cmd)
+    print("Unknown command:", cmd)

--- a/utemplate_util.py
+++ b/utemplate_util.py
@@ -41,7 +41,7 @@ elif cmd == "render":
 elif cmd == "run":
     f_out = io.StringIO()
     with open(sys.argv[2]) as f_in:
-        c = utemplate.source.Compiler(f_in, f_out)
+        c = utemplate.source.Compiler(f_in, f_out, loader=utemplate.source.Loader(None, "."))
         c.compile()
     ns = {}
     exec(f_out.getvalue(), ns)

--- a/utemplate_util.py
+++ b/utemplate_util.py
@@ -1,8 +1,6 @@
 import sys
-try:
-    import uos as os
-except ImportError:
-    import os
+import os
+import os.path
 try:
     import uio as io
 except ImportError:
@@ -41,7 +39,8 @@ elif cmd == "render":
 elif cmd == "run":
     f_out = io.StringIO()
     with open(sys.argv[2]) as f_in:
-        c = utemplate.source.Compiler(f_in, f_out, loader=utemplate.source.Loader(None, "."))
+        c = utemplate.source.Compiler(f_in, f_out,
+            loader=utemplate.source.Loader(None, os.path.dirname(sys.argv[2]) or "."))
         c.compile()
     ns = {}
     exec(f_out.getvalue(), ns)


### PR DESCRIPTION
Loader now wires include directives properly by default from utemplate_util.py - really useful for debugging against upstream